### PR TITLE
fix: fps config now behaves as frames-per-second (higher = faster)

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -14,4 +14,4 @@ duration:
   awake_rand: 20
 idle_space: 10
 animal: neko
-fps: 300
+fps: 5

--- a/neko2020/__main__.py
+++ b/neko2020/__main__.py
@@ -21,13 +21,13 @@ def stop(root):
         return
     STOP_UPDATE = True
 
-    fps = configs.get_int("fps")
+    delay_ms = 1000 // configs.get_int("fps")
 
     # this is to keep the application running when neko is hidden
     def nop():
         if not STOP_UPDATE:
             return
-        root.after(fps, nop)
+        root.after(delay_ms, nop)
 
     nop()
 
@@ -42,22 +42,22 @@ def start(root, canvas):
     # reload config
     configs.load_config()
     myNeko = neko.Neko(root, canvas)
-    fps = configs.get_int("fps")
+    delay_ms = 1000 // configs.get_int("fps")
 
-    def timer(root, myNeko, fps=200):
+    def timer(root, myNeko, delay_ms=125):
         if STOP_UPDATE:
             return
         myNeko.update()
-        root.after(fps, lambda: timer(root, myNeko, fps))
+        root.after(delay_ms, lambda: timer(root, myNeko, delay_ms))
 
-    timer(root, myNeko, fps)
+    timer(root, myNeko, delay_ms)
 
 
 def restart(root, canvas):
-    fps = configs.get_int("fps")
+    delay_ms = 1000 // configs.get_int("fps")
     stop(root)
     # sleep before restarting to let the old instance have time to exit.
-    time.sleep(2 * fps / 1000)
+    time.sleep(2 * delay_ms / 1000)
     start(root, canvas)
 
 


### PR DESCRIPTION
## Summary

- `fps` config value was used directly as a millisecond delay, so higher values meant slower animation — the opposite of what users expect
- Now converts to `delay_ms = 1000 // fps` so the config behaves as true frames-per-second
- Default changed from `300` (ms delay, ~3 fps) to `5` (fps, 200ms delay)

Closes #131

## Test plan
- [ ] Run the app and verify neko animates at roughly 5 fps by default
- [ ] Set `fps: 10` in config and confirm animation is faster than default
- [ ] Set `fps: 2` in config and confirm animation is slower than default

🤖 Generated with [Claude Code](https://claude.com/claude-code)