### PR TITLE
chore: clean up dependabot config and add github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,31 +3,8 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: black
-    versions:
-    - 21.4b0
-    - 21.4b1
-  - dependency-name: pre-commit
-    versions:
-    - 2.10.0
-    - 2.10.1
-    - 2.11.0
-    - 2.11.1
-    - 2.12.0
-  - dependency-name: flake8
-    versions:
-    - 3.9.0
-  - dependency-name: pillow
-    versions:
-    - 8.1.0
-    - 8.1.1
-    - 8.1.2
-  - dependency-name: pytest
-    versions:
-    - 6.2.2
-  - dependency-name: pyinstaller
-    versions:
-    - "4.2"
+    interval: weekly
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Remove stale version ignore rules, switch pip to weekly, and add github-actions ecosystem to track workflow action pin updates.