### PR TITLE
docs: set git workflow to branch from and PR to develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,8 @@ Create `resource/<name>/` with all 32 `.ico` files. File names must exactly matc
 
 - Ruff format with 79-character line length (enforced by pre-commit)
 - Ruff lint (E/F/W rules, enforced by pre-commit)
+
+## Git Workflow
+
+- Always branch from `develop`, not `master`
+- Always target `develop` as the PR base branch


### PR DESCRIPTION
## Summary
- Added Git Workflow section to CLAUDE.md
- Instructs Claude Code to always branch from `develop` and target `develop` for PRs

## Test plan
- No code changes; documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)