### PR TITLE
feat: load user icons from ~/.config/neko2020/resources/

### DIFF
--- a/neko2020/adapters/tkinter_renderer.py
+++ b/neko2020/adapters/tkinter_renderer.py
@@ -13,12 +13,16 @@ class TkinterRenderer(IRenderer):
         self._bounds = Rect(0, 0, canvas.winfo_width(), canvas.winfo_height())
 
         pet_type = config.get_string("animal")
+        user_resource_base = files.get_user_resource_dir()
         if pet_type == "random":
-            pet_type = files.select_random_directory(
-                os.path.join(files.get_project_root(), "resource")
+            pet_type = files.select_random_directory_merged(
+                os.path.join(files.get_project_root(), "resource"),
+                user_resource_base,
             )
 
-        self._images, img_w, img_h = image_loader.load_images(pet_type)
+        self._images, img_w, img_h = image_loader.load_images(
+            pet_type, user_resource_base=user_resource_base
+        )
         self._size = Size(img_w, img_h)
         self._last_frame_index: int | None = None
 

--- a/neko2020/infrastructure/files.py
+++ b/neko2020/infrastructure/files.py
@@ -6,7 +6,34 @@ def get_project_root():
     return os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 
+def get_user_resource_dir():
+    xdg_config_home = os.getenv(
+        "XDG_CONFIG_HOME",
+        os.path.join(os.path.expanduser("~"), ".config"),
+    )
+    return os.path.join(xdg_config_home, "neko2020", "resources")
+
+
 def select_random_directory(basedir):
-    files = os.listdir(basedir)
-    directories = [f for f in files if os.path.isdir(os.path.join(basedir, f))]
+    entries = os.listdir(basedir)
+    directories = [
+        f for f in entries if os.path.isdir(os.path.join(basedir, f))
+    ]
     return random.choice(directories)
+
+
+def select_random_directory_merged(project_basedir, user_basedir):
+    dirs = set()
+    if os.path.isdir(project_basedir):
+        dirs.update(
+            f
+            for f in os.listdir(project_basedir)
+            if os.path.isdir(os.path.join(project_basedir, f))
+        )
+    if os.path.isdir(user_basedir):
+        dirs.update(
+            f
+            for f in os.listdir(user_basedir)
+            if os.path.isdir(os.path.join(user_basedir, f))
+        )
+    return random.choice(list(dirs))

--- a/neko2020/infrastructure/image_loader.py
+++ b/neko2020/infrastructure/image_loader.py
@@ -13,7 +13,19 @@ def resize_image(img, scale):
     )
 
 
-def load_images(animal="neko", scale={"x": 1.0, "y": 1.0}):
+def _resolve_animal_dir(animal, user_resource_base):
+    if user_resource_base:
+        user_dir = os.path.join(user_resource_base, animal)
+        if os.path.isdir(user_dir):
+            return user_dir
+    return os.path.join(files.get_project_root(), "resource", animal)
+
+
+def load_images(
+    animal="neko",
+    scale={"x": 1.0, "y": 1.0},
+    user_resource_base=None,
+):
     # fmt: off
     icon_names = [
         "Awake", "up1", "up2", "upright1", "upright2",
@@ -29,7 +41,7 @@ def load_images(animal="neko", scale={"x": 1.0, "y": 1.0}):
 
     icons = []
 
-    base_icon_dir = os.path.join(files.get_project_root(), "resource", animal)
+    base_icon_dir = _resolve_animal_dir(animal, user_resource_base)
     for name in icon_names:
         icon_path = os.path.join(base_icon_dir, ".".join([name, "ico"]))
         img = Image.open(icon_path)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Icons placed under `~/.config/neko2020/resources/{pet_name}/` now take precedence over the built-in `resource/` directory when the same pet name exists in both locations
- User-defined pets in `~/.config/neko2020/resources/` are included in the random selection pool alongside built-in pets
- Respects `XDG_CONFIG_HOME` env var (falls back to `~/.config`)

## Changes

- `infrastructure/files.py`: added `get_user_resource_dir()` and `select_random_directory_merged()` to resolve and enumerate user resource dirs
- `infrastructure/image_loader.py`: added `_resolve_animal_dir()` helper; `load_images()` accepts `user_resource_base` and checks the user dir first
- `adapters/tkinter_renderer.py`: passes user resource base into both random selection and image loading

## Test plan

- [x] Place 32 `.ico` files under `~/.config/neko2020/resources/my_pet/` and set `animal: my_pet` in user config — pet should load from user dir
- [x] Place a same-named pet dir in both locations — user dir icons are used
- [x] Set `animal: random` — user-defined pets appear in the random pool
- [x] No user resource dir present — behaviour unchanged (falls back to built-in `resource/`)

Closes #174

https://claude.ai/code/session_01EqSxBVNJRjd8WVwMMA927q
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqSxBVNJRjd8WVwMMA927q)_