### PR TITLE
refactor: move imgen and imgen-gpt to extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,16 +13,7 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/tajas20006/neko2020"
 
-[dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-    "ruff>=0.15.12",
-    "pyinstaller>=6.20.0",
-    "pywin32-ctypes>=0.2.3",
-    "pywin32>=311",
-    "pre-commit>=4.6.0",
-    "pefile>=2024.8.26",
-]
+[project.optional-dependencies]
 imgen = [
     "accelerate>=1.13.0",
     "diffusers>=0.37.1",
@@ -36,6 +27,17 @@ imgen = [
 imgen-gpt = [
     "openai>=1.0.0",
     "rembg[cpu]>=2.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "ruff>=0.15.12",
+    "pyinstaller>=6.20.0",
+    "pywin32-ctypes>=0.2.3",
+    "pywin32>=311",
+    "pre-commit>=4.6.0",
+    "pefile>=2024.8.26",
 ]
 
 [[tool.uv.index]]

--- a/tools/README.md
+++ b/tools/README.md
@@ -13,14 +13,14 @@ Requires an OpenAI API key (`OPENAI_API_KEY` environment variable).
 **Cost: ~$1.50 per full set of 32 icons.**
 
 ```bash
-uv sync --group imgen-gpt
+uv sync --extra imgen-gpt
 
 # From a text prompt
-uv run --group imgen-gpt python tools/generate_pet_gpt.py \
+uv run --extra imgen-gpt python tools/generate_pet_gpt.py \
     --name mycat --prompt "cute orange tabby cat"
 
 # From a hand-drawn character (recommended for best results)
-uv run --group imgen-gpt python tools/generate_pet_gpt.py \
+uv run --extra imgen-gpt python tools/generate_pet_gpt.py \
     --name mycat --prompt "cute orange tabby cat" \
     --base-image mycharacter.png
 ```
@@ -45,9 +45,9 @@ Uses Stable Diffusion locally via diffusers. No API cost, but requires
 a CUDA GPU and several GB of VRAM.
 
 ```bash
-uv sync --group imgen
+uv sync --extra imgen
 
-uv run --group imgen python tools/generate_pet.py \
+uv run --extra imgen python tools/generate_pet.py \
     --name mycat --prompt "cute orange tabby cat"
 ```
 

--- a/uv.lock
+++ b/uv.lock
@@ -618,16 +618,7 @@ dependencies = [
     { name = "pyyaml" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pefile" },
-    { name = "pre-commit" },
-    { name = "pyinstaller" },
-    { name = "pytest" },
-    { name = "pywin32" },
-    { name = "pywin32-ctypes" },
-    { name = "ruff" },
-]
+[package.optional-dependencies]
 imgen = [
     { name = "accelerate" },
     { name = "diffusers" },
@@ -643,12 +634,34 @@ imgen-gpt = [
     { name = "rembg", extra = ["cpu"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pefile" },
+    { name = "pre-commit" },
+    { name = "pyinstaller" },
+    { name = "pytest" },
+    { name = "pywin32" },
+    { name = "pywin32-ctypes" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", marker = "extra == 'imgen'", specifier = ">=1.13.0" },
+    { name = "diffusers", marker = "extra == 'imgen'", specifier = ">=0.37.1" },
+    { name = "ollama", marker = "extra == 'imgen'", specifier = ">=0.4.0" },
+    { name = "openai", marker = "extra == 'imgen-gpt'", specifier = ">=1.0.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pystray", specifier = ">=0.19.5" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "rembg", extras = ["cpu"], marker = "extra == 'imgen'", specifier = ">=2.0.0" },
+    { name = "rembg", extras = ["cpu"], marker = "extra == 'imgen-gpt'", specifier = ">=2.0.0" },
+    { name = "safetensors", marker = "extra == 'imgen'", specifier = ">=0.7.0" },
+    { name = "torch", marker = "extra == 'imgen'", specifier = ">=2.11.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchvision", marker = "extra == 'imgen'", specifier = ">=0.26.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "transformers", marker = "extra == 'imgen'", specifier = ">=5.8.0" },
 ]
+provides-extras = ["imgen", "imgen-gpt"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -659,20 +672,6 @@ dev = [
     { name = "pywin32", specifier = ">=311" },
     { name = "pywin32-ctypes", specifier = ">=0.2.3" },
     { name = "ruff", specifier = ">=0.15.12" },
-]
-imgen = [
-    { name = "accelerate", specifier = ">=1.13.0" },
-    { name = "diffusers", specifier = ">=0.37.1" },
-    { name = "ollama", specifier = ">=0.4.0" },
-    { name = "rembg", extras = ["cpu"], specifier = ">=2.0.0" },
-    { name = "safetensors", specifier = ">=0.7.0" },
-    { name = "torch", specifier = ">=2.11.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torchvision", specifier = ">=0.26.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "transformers", specifier = ">=5.8.0" },
-]
-imgen-gpt = [
-    { name = "openai", specifier = ">=1.0.0" },
-    { name = "rembg", extras = ["cpu"], specifier = ">=2.0.0" },
 ]
 
 [[package]]
@@ -926,6 +925,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/b1/d111b1df656761f980d9e298a60039a9cb66036b1d039e777537743d0ac3/onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac", size = 18016624, upload-time = "2026-05-12T00:41:01.735Z" },
     { url = "https://files.pythonhosted.org/packages/f6/a0/3f9d896a0385a36bd04345d6d0b802821a5782adde562e7e135f6bb71c73/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:91f2bb870a4b9224eba0a6728c1fa7a9e552b8e59e1083c51fbbc3d013f2b5c0", size = 16052692, upload-time = "2026-05-08T19:07:13.829Z" },
     { url = "https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6", size = 18185439, upload-time = "2026-05-08T19:07:36.299Z" },
     { url = "https://files.pythonhosted.org/packages/44/fc/026d0a7162b9c2153dac292baea9e027c42304dc1d9dc6f8ff5b4cfbaedd/onnxruntime-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:a26374dc7fbcaae593601086b242120e13f2310558df0991da6dd8b8fac00414", size = 13026427, upload-time = "2026-05-08T19:08:03.503Z" },


### PR DESCRIPTION
## Summary

- Moved `imgen` and `imgen-gpt` from `[dependency-groups]` to `[project.optional-dependencies]` in `pyproject.toml`
- Updated `tools/README.md` to use `--extra` flag instead of `--group`
- Updated `uv.lock` accordingly

## Test plan

- [x] `uv sync --extra imgen` installs imgen dependencies
- [x] `uv sync --extra imgen-gpt` installs imgen-gpt dependencies
- [x] `uv run --extra imgen python tools/generate_pet.py --help` runs without error
- [x] `uv run --extra imgen-gpt python tools/generate_pet_gpt.py --help` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)