### PR TITLE
Add unit tests for image_loader, tkinter_cursor, and tkinter_renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Install tkinter
+        run: sudo apt-get install -y python3-tk
+
       - name: Install dependencies
         run: uv sync --frozen
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@ neko2020/
      Add project-specific conventions, gotchas, and workflow requirements here. -->
 
 - **Bump version before merging to master**: The CI workflow (`build-exe.yml`) creates a GitHub Release tagged with the version from `pyproject.toml`. Before any PR lands on master, update `version` in `pyproject.toml` to avoid overwriting an existing release tag.
+- **Run ruff format before every commit**: Always run `uv run ruff format neko2020/ tests/` (then `uv run ruff check neko2020/ tests/`) before staging and committing. The 79-char line limit is enforced by CI and will fail the build if violated.

--- a/tests/test_image_loader.py
+++ b/tests/test_image_loader.py
@@ -1,0 +1,163 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from neko2020.infrastructure import files
+from neko2020.infrastructure.image_loader import (
+    _resolve_animal_dir,
+    load_images,
+    resize_image,
+)
+
+
+# ---------------------------------------------------------------------------
+# resize_image
+# ---------------------------------------------------------------------------
+
+
+def test_resize_image_scalar_int_applies_to_both_axes():
+    img = MagicMock()
+    img.width = 10
+    img.height = 20
+    resize_image(img, 3)
+    img.resize.assert_called_once_with((30, 60))
+
+
+def test_resize_image_scalar_float_applies_to_both_axes():
+    img = MagicMock()
+    img.width = 32
+    img.height = 32
+    resize_image(img, 2.0)
+    img.resize.assert_called_once_with((64, 64))
+
+
+def test_resize_image_dict_scale_applies_axes_independently():
+    img = MagicMock()
+    img.width = 32
+    img.height = 32
+    resize_image(img, {"x": 2.0, "y": 0.5})
+    img.resize.assert_called_once_with((64, 16))
+
+
+def test_resize_image_returns_result_of_resize():
+    img = MagicMock()
+    img.width = 10
+    img.height = 20
+    result = resize_image(img, 1.0)
+    assert result is img.resize.return_value
+
+
+# ---------------------------------------------------------------------------
+# _resolve_animal_dir
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_animal_dir_returns_project_resource_when_no_user_base():
+    result = _resolve_animal_dir("neko", None)
+    expected = os.path.join(files.get_project_root(), "resource", "neko")
+    assert result == expected
+
+
+def test_resolve_animal_dir_uses_user_dir_when_it_exists(tmp_path):
+    (tmp_path / "neko").mkdir()
+    result = _resolve_animal_dir("neko", str(tmp_path))
+    assert result == str(tmp_path / "neko")
+
+
+def test_resolve_animal_dir_falls_back_to_project_when_user_subdir_missing(
+    tmp_path,
+):
+    # tmp_path exists but has no "neko" subdirectory
+    result = _resolve_animal_dir("neko", str(tmp_path))
+    expected = os.path.join(files.get_project_root(), "resource", "neko")
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# load_images
+# ---------------------------------------------------------------------------
+
+
+def _mock_img(w=32, h=32):
+    img = MagicMock()
+    img.width = w
+    img.height = h
+    img.resize.return_value = img
+    return img
+
+
+def test_load_images_returns_32_icons():
+    mock_img = _mock_img()
+    with (
+        patch(
+            "neko2020.infrastructure.image_loader.Image.open",
+            return_value=mock_img,
+        ),
+        patch("neko2020.infrastructure.image_loader.ImageTk.PhotoImage"),
+    ):
+        icons, _w, _h = load_images("neko")
+    assert len(icons) == 32
+
+
+def test_load_images_returns_image_dimensions():
+    mock_img = _mock_img(w=48, h=48)
+    with (
+        patch(
+            "neko2020.infrastructure.image_loader.Image.open",
+            return_value=mock_img,
+        ),
+        patch("neko2020.infrastructure.image_loader.ImageTk.PhotoImage"),
+    ):
+        _icons, w, h = load_images("neko")
+    assert w == 48
+    assert h == 48
+
+
+def test_load_images_wraps_each_frame_in_photo_image():
+    mock_img = _mock_img()
+    with (
+        patch(
+            "neko2020.infrastructure.image_loader.Image.open",
+            return_value=mock_img,
+        ),
+        patch(
+            "neko2020.infrastructure.image_loader.ImageTk.PhotoImage"
+        ) as mock_photo,
+    ):
+        icons, _w, _h = load_images("neko")
+    assert mock_photo.call_count == 32
+    assert len(icons) == 32
+
+
+def test_load_images_applies_scalar_scale():
+    mock_img = _mock_img(w=32, h=32)
+    with (
+        patch(
+            "neko2020.infrastructure.image_loader.Image.open",
+            return_value=mock_img,
+        ),
+        patch("neko2020.infrastructure.image_loader.ImageTk.PhotoImage"),
+    ):
+        load_images("neko", scale=2.0)
+    mock_img.resize.assert_called_with((64, 64))
+
+
+def test_load_images_resolves_icons_under_user_resource_base(tmp_path):
+    (tmp_path / "neko").mkdir()
+    mock_img = _mock_img()
+    opened_paths = []
+
+    def _fake_open(path):
+        opened_paths.append(path)
+        return mock_img
+
+    with (
+        patch(
+            "neko2020.infrastructure.image_loader.Image.open",
+            side_effect=_fake_open,
+        ),
+        patch("neko2020.infrastructure.image_loader.ImageTk.PhotoImage"),
+    ):
+        load_images("neko", user_resource_base=str(tmp_path))
+
+    user_neko_dir = str(tmp_path / "neko")
+    assert all(p.startswith(user_neko_dir) for p in opened_paths)

--- a/tests/test_tkinter_cursor.py
+++ b/tests/test_tkinter_cursor.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+
+from neko2020.adapters.tkinter_cursor import TkinterCursorProvider
+from neko2020.domain.value_objects import Point
+
+
+# ---------------------------------------------------------------------------
+# get_cursor_position
+# ---------------------------------------------------------------------------
+
+
+def test_get_cursor_position_returns_point():
+    root = MagicMock()
+    root.winfo_pointerx.return_value = 100
+    root.winfo_pointery.return_value = 200
+    provider = TkinterCursorProvider(root)
+    result = provider.get_cursor_position()
+    assert isinstance(result, Point)
+
+
+def test_get_cursor_position_xy_match_winfo_values():
+    root = MagicMock()
+    root.winfo_pointerx.return_value = 100
+    root.winfo_pointery.return_value = 200
+    provider = TkinterCursorProvider(root)
+    result = provider.get_cursor_position()
+    assert result.x == 100
+    assert result.y == 200
+
+
+def test_get_cursor_position_calls_winfo_methods_each_invocation():
+    root = MagicMock()
+    root.winfo_pointerx.return_value = 0
+    root.winfo_pointery.return_value = 0
+    provider = TkinterCursorProvider(root)
+    provider.get_cursor_position()
+    provider.get_cursor_position()
+    assert root.winfo_pointerx.call_count == 2
+    assert root.winfo_pointery.call_count == 2
+
+
+def test_get_cursor_position_reflects_updated_values():
+    root = MagicMock()
+    root.winfo_pointerx.side_effect = [10, 50]
+    root.winfo_pointery.side_effect = [20, 80]
+    provider = TkinterCursorProvider(root)
+    first = provider.get_cursor_position()
+    second = provider.get_cursor_position()
+    assert first == Point(10, 20)
+    assert second == Point(50, 80)

--- a/tests/test_tkinter_renderer.py
+++ b/tests/test_tkinter_renderer.py
@@ -69,7 +69,9 @@ def test_get_bounds_covers_canvas_area_with_offset():
 
 
 def test_get_bounds_zero_origin():
-    renderer, _c, _imgs = _make_renderer(vx=0, vy=0, canvas_w=1920, canvas_h=1080)
+    renderer, _c, _imgs = _make_renderer(
+        vx=0, vy=0, canvas_w=1920, canvas_h=1080
+    )
     assert renderer.get_bounds() == Rect(0, 0, 1920, 1080)
 
 

--- a/tests/test_tkinter_renderer.py
+++ b/tests/test_tkinter_renderer.py
@@ -1,0 +1,188 @@
+from unittest.mock import MagicMock, patch
+
+from neko2020.adapters.tkinter_renderer import TkinterRenderer
+from neko2020.domain.value_objects import Point, Rect, Size
+
+_ICON_COUNT = 32
+
+
+def _make_canvas(w=800, h=600):
+    canvas = MagicMock()
+    canvas.winfo_width.return_value = w
+    canvas.winfo_height.return_value = h
+    return canvas
+
+
+def _make_config(animal="neko"):
+    config = MagicMock()
+    config.get_string.return_value = animal
+    return config
+
+
+def _make_renderer(
+    animal="neko",
+    vx=0,
+    vy=0,
+    canvas_w=800,
+    canvas_h=600,
+    initial=Point(100, 100),
+):
+    canvas = _make_canvas(canvas_w, canvas_h)
+    config = _make_config(animal)
+    mock_images = [MagicMock() for _ in range(_ICON_COUNT)]
+
+    with (
+        patch(
+            "neko2020.adapters.tkinter_renderer.image_loader.load_images",
+            return_value=(mock_images, 32, 32),
+        ),
+        patch(
+            "neko2020.adapters.tkinter_renderer.files.get_user_resource_dir",
+            return_value=None,
+        ),
+    ):
+        renderer = TkinterRenderer(canvas, config, vx, vy, initial)
+
+    return renderer, canvas, mock_images
+
+
+# ---------------------------------------------------------------------------
+# get_position / get_size / get_bounds
+# ---------------------------------------------------------------------------
+
+
+def test_get_position_returns_initial_position():
+    renderer, _c, _imgs = _make_renderer(initial=Point(42, 77))
+    assert renderer.get_position() == Point(42, 77)
+
+
+def test_get_size_reflects_image_dimensions():
+    renderer, _c, _imgs = _make_renderer()
+    assert renderer.get_size() == Size(32, 32)
+
+
+def test_get_bounds_covers_canvas_area_with_offset():
+    renderer, _c, _imgs = _make_renderer(
+        vx=10, vy=20, canvas_w=800, canvas_h=600
+    )
+    assert renderer.get_bounds() == Rect(10, 20, 810, 620)
+
+
+def test_get_bounds_zero_origin():
+    renderer, _c, _imgs = _make_renderer(vx=0, vy=0, canvas_w=1920, canvas_h=1080)
+    assert renderer.get_bounds() == Rect(0, 0, 1920, 1080)
+
+
+# ---------------------------------------------------------------------------
+# render
+# ---------------------------------------------------------------------------
+
+
+def test_render_clears_canvas_before_drawing():
+    renderer, canvas, _imgs = _make_renderer()
+    renderer.render(0, 100, 100)
+    canvas.delete.assert_called_with("all")
+
+
+def test_render_creates_image_on_canvas():
+    renderer, canvas, _imgs = _make_renderer()
+    renderer.render(0, 100, 100)
+    canvas.create_image.assert_called_once()
+
+
+def test_render_subtracts_virtual_origin_from_coords():
+    renderer, canvas, _imgs = _make_renderer(vx=50, vy=30)
+    renderer.render(0, 200, 130)
+    args = canvas.create_image.call_args.args
+    assert args[0] == 150  # 200 - 50
+    assert args[1] == 100  # 130 - 30
+
+
+def test_render_passes_correct_frame_image():
+    renderer, canvas, imgs = _make_renderer()
+    renderer.render(5, 100, 100)
+    kwargs = canvas.create_image.call_args.kwargs
+    assert kwargs["image"] is imgs[5]
+
+
+def test_render_updates_stored_position():
+    renderer, _c, _imgs = _make_renderer(initial=Point(0, 0))
+    renderer.render(0, 300, 400)
+    assert renderer.get_position() == Point(300, 400)
+
+
+def test_render_skips_redraw_when_frame_and_position_unchanged():
+    renderer, canvas, _imgs = _make_renderer(initial=Point(0, 0))
+    renderer.render(0, 100, 100)
+    canvas.reset_mock()
+    renderer.render(0, 100, 100)
+    canvas.delete.assert_not_called()
+    canvas.create_image.assert_not_called()
+
+
+def test_render_redraws_when_frame_index_changes():
+    renderer, canvas, _imgs = _make_renderer()
+    renderer.render(0, 100, 100)
+    canvas.reset_mock()
+    renderer.render(1, 100, 100)
+    canvas.create_image.assert_called_once()
+
+
+def test_render_redraws_when_position_changes():
+    renderer, canvas, _imgs = _make_renderer()
+    renderer.render(0, 100, 100)
+    canvas.reset_mock()
+    renderer.render(0, 200, 100)
+    canvas.create_image.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# random animal selection
+# ---------------------------------------------------------------------------
+
+
+def test_random_animal_calls_select_random_directory_merged():
+    canvas = _make_canvas()
+    config = _make_config("random")
+    mock_images = [MagicMock() for _ in range(_ICON_COUNT)]
+
+    with (
+        patch(
+            "neko2020.adapters.tkinter_renderer.image_loader.load_images",
+            return_value=(mock_images, 32, 32),
+        ),
+        patch(
+            "neko2020.adapters.tkinter_renderer.files.get_user_resource_dir",
+            return_value="/some/path",
+        ),
+        patch(
+            "neko2020.adapters.tkinter_renderer.files.select_random_directory_merged",
+            return_value="neko",
+        ) as mock_rand,
+    ):
+        TkinterRenderer(canvas, config, 0, 0, Point(0, 0))
+
+    mock_rand.assert_called_once()
+
+
+def test_non_random_animal_does_not_call_select_random_directory_merged():
+    canvas = _make_canvas()
+    config = _make_config("neko")
+    mock_images = [MagicMock() for _ in range(_ICON_COUNT)]
+
+    with (
+        patch(
+            "neko2020.adapters.tkinter_renderer.image_loader.load_images",
+            return_value=(mock_images, 32, 32),
+        ),
+        patch(
+            "neko2020.adapters.tkinter_renderer.files.get_user_resource_dir",
+            return_value=None,
+        ),
+        patch(
+            "neko2020.adapters.tkinter_renderer.files.select_random_directory_merged",
+        ) as mock_rand,
+    ):
+        TkinterRenderer(canvas, config, 0, 0, Point(0, 0))
+
+    mock_rand.assert_not_called()


### PR DESCRIPTION
Covers resize_image, _resolve_animal_dir, load_images, TkinterCursorProvider, and TkinterRenderer (render logic, bounds, frame skipping, random animal) using mocks so no GUI or .ico files are required.