### PR TITLE
feat: idle wandering — sleeping pet occasionally chases a random point

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -12,6 +12,10 @@ duration:
   awake: 3
   claw: 10
   awake_rand: 20
+wander:
+  enabled: false
+  sleep_time: 100
+  rand: 100
 idle_space: 10
 animal: neko
 fps: 4

--- a/neko2020/__main__.py
+++ b/neko2020/__main__.py
@@ -73,6 +73,9 @@ def _build_state_machine(config: IConfigProvider) -> NekoStateMachine:
         max_speed=config.get_int("speed.max"),
         idle_space=config.get_int("idle_space"),
         offset=Point(config.get_int("offset.x"), config.get_int("offset.y")),
+        wander_enabled=config.get_bool("wander.enabled"),
+        wander_time=config.get_int("wander.sleep_time"),
+        wander_rand=config.get_int("wander.rand"),
     )
 
 

--- a/neko2020/adapters/yaml_config.py
+++ b/neko2020/adapters/yaml_config.py
@@ -50,3 +50,8 @@ class YamlConfigProvider(IConfigProvider):
 
     def get_string(self, path: str) -> str:
         return str(self._get_value(path))
+
+    def get_bool(self, path: str) -> bool:
+        # BaseLoader keeps YAML scalars as strings, so parse them here.
+        value = str(self._get_value(path)).strip().lower()
+        return value in ("true", "1", "yes", "on")

--- a/neko2020/application/ports.py
+++ b/neko2020/application/ports.py
@@ -14,6 +14,9 @@ class IConfigProvider(ABC):
     def get_string(self, path: str) -> str: ...
 
     @abstractmethod
+    def get_bool(self, path: str) -> bool: ...
+
+    @abstractmethod
     def reload(self) -> None: ...
 
 

--- a/neko2020/domain/state_machine.py
+++ b/neko2020/domain/state_machine.py
@@ -58,6 +58,9 @@ class NekoStateMachine:
         max_speed: int,
         idle_space: int,
         offset: Point,
+        wander_enabled: bool = False,
+        wander_time: int = 100,
+        wander_rand: int = 100,
     ):
         self.STOP_TIME = stop_time
         self.WASH_TIME = wash_time
@@ -66,6 +69,9 @@ class NekoStateMachine:
         self.AWAKE_TIME = awake_time
         self.CLAW_TIME = claw_time
         self.AWK_RND = awake_rand
+        self.wander_enabled = wander_enabled
+        self.WANDER_TIME = wander_time
+        self.WANDER_RND = wander_rand
 
         self.animation = {
             State.STOP: [28, 28, 28, 28],
@@ -103,6 +109,7 @@ class NekoStateMachine:
         self.tick_count = 0
         self.state_count = 0
         self.state = State.STOP
+        self.wander_target: Point | None = None
 
     def _move_start(self):
         return (
@@ -146,10 +153,21 @@ class NekoStateMachine:
     def _set_new_state(self, state):
         if self.state == state:
             return
+        if state == State.STOP:
+            # arrived (or gave up): resume the normal idle cycle
+            self.wander_target = None
         self.tick_count = 0
         self.state_count = 0
         self.state = state
         return self.state
+
+    def _pick_wander_target(self, size: Size, bounds: Rect) -> Point:
+        half_cx = size.cx // 2
+        half_cy = size.cy // 2
+        return Point(
+            random.randint(bounds.left + half_cx, bounds.right - half_cx),
+            random.randint(bounds.top + half_cy, bounds.bottom - half_cy),
+        )
 
     def _frame_index(self):
         return self.animation[self.state][self.tick_count]
@@ -161,28 +179,36 @@ class NekoStateMachine:
         size: Size,
         bounds: Rect,
     ) -> TickResult:
-        new_x_target = cursor.x
-        new_y_target = cursor.y
-
         self.old_x = self.to_x
         self.old_y = self.to_y
-        self.to_x = new_x_target
-        self.to_y = new_y_target
+        self.to_x = cursor.x
+        self.to_y = cursor.y
+
+        # real cursor movement always cancels wandering
+        if self.wander_target is not None and self._move_start():
+            self.wander_target = None
+
+        if self.wander_target is not None:
+            target_x = self.wander_target.x
+            target_y = self.wander_target.y
+        else:
+            target_x = cursor.x
+            target_y = cursor.y
 
         half_cx = size.cx // 2
         half_cy = size.cy // 2
-        if self.to_x <= bounds.left + half_cx:
+        if target_x <= bounds.left + half_cx:
             dx = bounds.left + half_cx - position.x
-        elif self.to_x >= bounds.right - half_cx:
+        elif target_x >= bounds.right - half_cx:
             dx = bounds.right - half_cx - position.x
         else:
-            dx = self.to_x - position.x + self.offset.x
-        if self.to_y <= bounds.top + half_cy:
+            dx = target_x - position.x + self.offset.x
+        if target_y <= bounds.top + half_cy:
             dy = bounds.top + half_cy - position.y
-        elif self.to_y >= bounds.bottom - half_cy:
+        elif target_y >= bounds.bottom - half_cy:
             dy = bounds.bottom - half_cy - position.y
         else:
-            dy = self.to_y - position.y + self.offset.y
+            dy = target_y - position.y + self.offset.y
         double_length = dx * dx + dy * dy
 
         if double_length != 0:
@@ -237,6 +263,11 @@ class NekoStateMachine:
                 self._set_new_state(State.SLEEP)
         elif self.state == State.SLEEP:
             if self._move_start():
+                self._set_new_state(State.AWAKE)
+            elif self.wander_enabled and self.state_count >= (
+                self.WANDER_TIME + int(random.random() * self.WANDER_RND)
+            ):
+                self.wander_target = self._pick_wander_target(size, bounds)
                 self._set_new_state(State.AWAKE)
         elif self.state == State.AWAKE:
             if self.state_count >= self.AWAKE_TIME + int(

--- a/neko2020/ui/config_dialog.py
+++ b/neko2020/ui/config_dialog.py
@@ -47,6 +47,16 @@ _SECTIONS: list[tuple[str, str, list[tuple[str, str, type]]]] = [
         ],
     ),
     (
+        "Wandering",
+        "Let a sleeping pet occasionally wake up and walk to a random "
+        "spot instead of sleeping forever.",
+        [
+            ("wander.enabled", "Enable Wandering", bool),
+            ("wander.sleep_time", "Sleep Before Wander", int),
+            ("wander.rand", "Wander Variance", int),
+        ],
+    ),
+    (
         "Performance",
         "Lower FPS reduces CPU usage; higher makes motion smoother.",
         [("fps", "FPS", int)],
@@ -156,10 +166,17 @@ class ConfigDialog:
                 font=("TkDefaultFont", 8),
             ).grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 6))
 
-            for i, (path, label, _typ) in enumerate(fields, start=1):
+            for i, (path, label, typ) in enumerate(fields, start=1):
                 tk.Label(tab, text=label + ":", anchor="w", width=22).grid(
                     row=i, column=0, sticky="w", pady=2
                 )
+                if typ is bool:
+                    bool_var = tk.BooleanVar(value=self._config.get_bool(path))
+                    self._vars[path] = bool_var
+                    tk.Checkbutton(tab, variable=bool_var).grid(
+                        row=i, column=1, sticky="w", pady=2, padx=(8, 0)
+                    )
+                    continue
                 value = self._config.get_string(path)
                 var = tk.StringVar(value=value)
                 self._vars[path] = var
@@ -200,7 +217,10 @@ class ConfigDialog:
     def _collect(self) -> dict | None:
         data: dict = {}
         for path, label, typ in _all_fields():
-            raw = self._vars[path].get().strip()
+            if typ is bool:
+                _set_nested(data, path, bool(self._vars[path].get()))
+                continue
+            raw = str(self._vars[path].get()).strip()
             if typ is int:
                 try:
                     val: int | str = int(raw)

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -316,3 +316,90 @@ def test_frame_index_for_stop_state_is_constant():
     # cursor at (0,0) stays in STOP (no cursor jump from initial to_x=0)
     result = sm.tick(Point(0, 0), CENTER, SIZE, BOUNDS)
     assert result.frame_index == 28  # animation[STOP] = [28, 28, 28, 28]
+
+
+# ---------------------------------------------------------------------------
+# Idle wandering
+# ---------------------------------------------------------------------------
+
+IDLE_CURSOR = Point(0, 0)
+
+
+def make_sleeping_sm(**overrides):
+    sm = make_sm(
+        stop_time=2,
+        wash_time=2,
+        scratch_time=2,
+        yawn_time=2,
+        awake_time=1,
+        **overrides,
+    )
+    tick_n(sm, 16, IDLE_CURSOR)
+    assert sm.state == State.SLEEP
+    return sm
+
+
+def test_wander_triggers_after_sleeping_long_enough():
+    sm = make_sleeping_sm(wander_enabled=True, wander_time=2, wander_rand=0)
+    # state_count increments every 2 ticks; below threshold → still asleep
+    tick_n(sm, 3, IDLE_CURSOR)
+    assert sm.state == State.SLEEP
+    tick_n(sm, 1, IDLE_CURSOR)
+    assert sm.state == State.AWAKE
+    assert sm.wander_target is not None
+
+
+def test_wander_disabled_sleeps_forever():
+    sm = make_sleeping_sm(wander_enabled=False, wander_time=2, wander_rand=0)
+    tick_n(sm, 50, IDLE_CURSOR)
+    assert sm.state == State.SLEEP
+    assert sm.wander_target is None
+
+
+def test_wander_target_is_within_bounds():
+    sm = make_sleeping_sm(wander_enabled=True, wander_time=2, wander_rand=0)
+    tick_n(sm, 4, IDLE_CURSOR)
+    target = sm.wander_target
+    assert BOUNDS.left + SIZE.cx // 2 <= target.x
+    assert target.x <= BOUNDS.right - SIZE.cx // 2
+    assert BOUNDS.top + SIZE.cy // 2 <= target.y
+    assert target.y <= BOUNDS.bottom - SIZE.cy // 2
+
+
+def test_wander_moves_toward_target(monkeypatch):
+    monkeypatch.setattr(
+        NekoStateMachine,
+        "_pick_wander_target",
+        lambda self, size, bounds: Point(1500, 540),
+    )
+    sm = make_sleeping_sm(wander_enabled=True, wander_time=2, wander_rand=0)
+    tick_n(sm, 4, IDLE_CURSOR)  # SLEEP → AWAKE with wander target
+    assert sm.wander_target == Point(1500, 540)
+    # AWAKE waits awake_time, then picks a direction toward the target
+    result = tick_n(sm, 3, IDLE_CURSOR)
+    assert sm.state == State.R_MOVE
+    assert result.x > CENTER.x
+
+
+def test_cursor_movement_cancels_wander(monkeypatch):
+    monkeypatch.setattr(
+        NekoStateMachine,
+        "_pick_wander_target",
+        lambda self, size, bounds: Point(1500, 540),
+    )
+    sm = make_sleeping_sm(wander_enabled=True, wander_time=2, wander_rand=0)
+    tick_n(sm, 7, IDLE_CURSOR)  # wandering: R_MOVE toward (1500, 540)
+    assert sm.state == State.R_MOVE
+    sm.tick(Point(300, 540), CENTER, SIZE, BOUNDS)
+    assert sm.wander_target is None
+    # next direction calc chases the real cursor (left of center)
+    sm.tick(Point(300, 540), CENTER, SIZE, BOUNDS)
+    assert sm.state == State.L_MOVE
+
+
+def test_reaching_stop_clears_wander_target():
+    sm = make_sm(wander_enabled=True, wander_time=2, wander_rand=0)
+    sm.wander_target = Point(1500, 540)
+    sm.state = State.R_MOVE
+    sm._set_new_state(State.STOP)
+    assert sm.wander_target is None

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -113,6 +113,29 @@ def test_get_string(tmp_path):
     assert p.get_string("animal") == "neko"
 
 
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+    ],
+)
+def test_get_bool(tmp_path, raw, expected):
+    f = tmp_path / "d.yml"
+    f.write_text(f"wander:\n  enabled: {raw}\n")
+    p = YamlConfigProvider(str(f), str(tmp_path / "x.yml"))
+    p.reload()
+    assert p.get_bool("wander.enabled") is expected
+
+
 def test_get_nested_value_via_dot_notation(tmp_path):
     f = tmp_path / "d.yml"
     f.write_text("speed:\n  max: 60\n")


### PR DESCRIPTION
Closes #193

## Summary

Adds an opt-in idle-wandering behavior: instead of sleeping forever once the cursor goes idle, the cat may wake up, walk to a random point on the current monitor, and then resume its normal idle cycle.

- While in `SLEEP`, after `wander.sleep_time` state counts (plus a random extra up to `wander.rand`), the state machine picks a random target within the monitor bounds (inset by half the sprite size) and chases it as if it were the cursor.
- On arrival it returns to `STOP`, so the wash → scratch → yawn → sleep cycle restarts and it may wander again later.
- Real cursor movement cancels the wander immediately and the cat chases the pointer as usual.

## Config

Off by default; deep-merges from user config as usual:

```yaml
wander:
  enabled: false
  sleep_time: 100
  rand: 100
```

## Changes

- `domain/state_machine.py`: wander trigger in `SLEEP`, wander target substitutes for the cursor while active, cleared on arrival (`STOP`) or real cursor movement
- `application/ports.py` + `adapters/yaml_config.py`: new `get_bool` accessor (BaseLoader keeps scalars as strings, so it parses true/1/yes/on)
- `__main__.py`: wander config wired into `_build_state_machine()`
- `ui/config_dialog.py`: new "Wandering" tab; adds checkbox support for bool fields (first bool in the dialog)
- `config/default_config.yml`: new `wander` section

## Testing

- New state-machine tests: trigger timing, stays asleep when disabled, target within bounds, movement toward target, cancel-on-cursor-move, target cleared on `STOP`
- New `get_bool` parsing tests
- `uv run pytest`: 139 passed; ruff format + check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)