### PR TITLE
docs: refresh CLAUDE.md, AGENTS.md, and .agents/summary for layered architecture

### DIFF
--- a/.agents/summary/architecture.md
+++ b/.agents/summary/architecture.md
@@ -1,13 +1,13 @@
 ---
 title: Architecture
-description: System architecture, design patterns, and Windows overlay approach
+description: Clean-architecture layers, Windows overlay approach, and animation loop design
 ---
 
 # Architecture
 
 ## High-Level Overview
 
-neko2020 is a single-process desktop application. The main thread runs a Tkinter event loop; a background thread drives the animation timer.
+neko2020 is a single-process desktop application organized in clean-architecture layers. The main thread runs the Tkinter event loop; the pystray tray icon runs detached on its own thread. Dependencies point inward: adapters/ui implement or use application ports; the domain has no I/O.
 
 ```mermaid
 graph TB
@@ -17,64 +17,74 @@ graph TB
     end
 
     subgraph App["neko2020 process"]
-        Main["__main__.py\nTkinter window + timer"]
-        Neko["neko.py\nState machine"]
-        Pet["pet.py\nCanvas renderer"]
-        Config["utils/configs.py\nYAML config"]
-        Images["utils/images.py\nSprite loader"]
+        Main["__main__.py\ncomposition root"]
+        Service["application/animation_service.py\nAnimationService"]
+        SM["domain/state_machine.py\nNekoStateMachine"]
+        Renderer["adapters/tkinter_renderer.py\nTkinterRenderer"]
+        CursorP["adapters/tkinter_cursor.py\nTkinterCursorProvider"]
+        Config["adapters/yaml_config.py\nYamlConfigProvider"]
+        Dialog["ui/config_dialog.py\nConfigDialog"]
+        Loader["infrastructure/image_loader.py"]
     end
 
-    Cursor -->|position poll| Main
-    Main -->|tick| Neko
-    Neko -->|state + position| Pet
-    Pet -->|draw icon| Main
-    Config -->|settings| Main
-    Config -->|settings| Neko
-    Images -->|PIL ImageTk| Pet
+    Cursor -->|position| CursorP
+    CursorP --> Service
+    Service -->|tick| SM
+    SM -->|TickResult| Service
+    Service -->|render| Renderer
+    Loader -->|PhotoImage list| Renderer
+    Config --> Service
+    Config --> Dialog
     Main <-->|start/stop/quit| SysTray
+    Dialog -->|write config + restart| Service
 ```
 
 ## Transparent Overlay Window
 
-The entire screen is covered by a single Tkinter window. Transparency is achieved by assigning a "transparent color" (green) to the window background and calling the Windows API to make that color invisible:
+A single Tkinter window covers the entire virtual screen (bounding box of all monitors, enumerated via `EnumDisplayMonitors`). Transparency comes from a "transparent color" (green) background; the window is undecorated, topmost, and disabled so mouse events pass through:
 
 ```
-root.attributes('-transparentcolor', 'green')
-root.attributes('-topmost', True)
-root.attributes('-fullscreen', True)
+root.overrideredirect(True)
+root.wm_attributes("-topmost", True)
+root.wm_attributes("-disabled", True)
+root.wm_attributes("-transparentcolor", "green")
 ```
 
-Mouse and keyboard events pass through the window via Windows API `SetWindowLong` flags (`WS_EX_TRANSPARENT | WS_EX_LAYERED`). The window is hidden from Alt+Tab with `WS_EX_TOOLWINDOW`.
+`WS_EX_TOOLWINDOW` (applied via ctypes `SetWindowLongW`) hides the window from Alt+Tab. Because Tk `geometry()` cannot express negative screen coordinates, the window is positioned with Win32 `SetWindowPos`.
 
 ## Animation Loop
 
-The Tkinter `after()` method drives the main animation loop at a configurable interval (default 300 ms). Each tick:
+`AnimationService` drives the loop with Tkinter's `after()` scheduler at `1000 // fps` ms per tick (default fps 4 → 250 ms). Each tick:
 
-1. Query cursor position
-2. Call `Neko.tick()` to update state and position
-3. Call `Pet.update()` to re-draw the sprite frame on the canvas
+1. Query cursor position via `ICursorProvider`
+2. Call `NekoStateMachine.tick(cursor, position, size, bounds)` — `bounds` is the monitor currently containing the cursor
+3. Call `IRenderer.render(frame_index, x, y)` to redraw the sprite
+4. Re-arm the scheduler
 
-## State Machine (neko.py)
+`start()`/`stop()`/`restart()` recreate the state machine and renderer through a session factory, so restarts pick up config changes. While stopped, an idle pump keeps the Tk loop alive.
+
+## State Machine (domain/state_machine.py)
 
 ```mermaid
 stateDiagram-v2
     [*] --> STOP
-    STOP --> WASH: idle_time >= stop_time
-    WASH --> SCRATCH: wash done
-    SCRATCH --> YAWN: scratch done
-    YAWN --> SLEEP: yawn done
+    STOP --> AWAKE: cursor moved > idle_space
+    STOP --> WASH: stop_time elapsed (mid-screen)
+    STOP --> X_CLAW: stop_time elapsed (at screen edge)
+    WASH --> SCRATCH: wash_time elapsed
+    X_CLAW --> SCRATCH: claw_time elapsed
+    SCRATCH --> YAWN: scratch_time elapsed
+    YAWN --> SLEEP: yawn_time elapsed
     SLEEP --> AWAKE: cursor moved
-    AWAKE --> [direction_move]: cursor far enough
-    [direction_move] --> STOP: near cursor
-    STOP --> [direction_move]: cursor moved
-    AWAKE --> STOP: cursor close
-    SLEEP --> AWAKE: cursor moved
+    AWAKE --> MOVE: awake_time (+rand) elapsed
+    MOVE --> STOP: reached cursor / pinned at boundary
 ```
 
-18 states total: `STOP`, `WASH`, `SCRATCH`, `YAWN`, `SLEEP`, `AWAKE`, `*_CLAW` (×4), and 8 directional movement states.
+18 states total: `STOP`, `WASH`, `SCRATCH`, `YAWN`, `SLEEP`, `AWAKE`, `*_CLAW` (×4), and 8 directional movement states. Direction is chosen by dividing the circle into 8 sectors using `sin(pi/8)` thresholds. Movement speed is capped at `speed.max` px/tick and clamped to the monitor bounds (inset by half the sprite size).
 
 ## Design Patterns
 
-- **State machine** — `Neko` owns all behavioral logic; `Pet` only renders
-- **Observer-lite** — `__main__` owns the tick and passes data down; no event bus
-- **Resource embedding** — PyInstaller bundles the entire `resource/` tree into the .exe
+- **Ports and adapters** — `application/ports.py` defines `IConfigProvider`, `ICursorProvider`, `IRenderer` ABCs; Tkinter/YAML specifics live in `adapters/`
+- **State machine** — `NekoStateMachine` owns all behavioral logic and returns a `TickResult`; the renderer only draws
+- **Session factory** — `__main__.py` supplies a factory creating fresh (state machine, renderer) pairs so restart reloads config and sprites
+- **Resource embedding** — PyInstaller bundles the entire `resource/` tree into the .exe; user sprite sets in `~/.config/neko2020/resources/` are checked first

--- a/.agents/summary/codebase_info.md
+++ b/.agents/summary/codebase_info.md
@@ -8,37 +8,41 @@ description: Basic metadata about the neko2020 project
 | Field | Value |
 |---|---|
 | Name | neko2020 |
-| Version | 0.1.2 |
-| Language | Python 3.12+ |
+| Version | 0.2.1 |
+| Language | Python >=3.12,<3.14 |
 | License | MIT |
-| Build System | Poetry |
+| Build System | uv + hatchling |
 | Repository | https://github.com/tajas20006/neko2020 |
 
 ## Description
 
-Cross-platform desktop pet (oneko-style) implemented in Python. A transparent overlay window renders an animated sprite that chases the mouse cursor, with system tray controls and 50+ configurable animal types.
+Desktop pet (oneko-style) for Windows implemented in Python. A transparent overlay window spanning all monitors renders an animated sprite that chases the mouse cursor, with system tray controls, a settings dialog, and 70+ animal sprite sets (plus AI generators for custom sets).
 
 ## Directory Layout
 
 ```
 neko2020/
-├── neko2020/          # Main source package
-│   ├── __main__.py    # Entry point, Tkinter window & system tray
-│   ├── neko.py        # State machine & movement logic
-│   ├── pet.py         # Visual rendering (canvas + sprites)
-│   └── utils/         # Data classes, config, file helpers, image loader
-├── config/            # default_config.yml
-├── resource/          # 50+ animal sprite sets (32 .ico frames each)
-├── tests/             # pytest test suite
-└── .github/workflows/ # Claude Code GitHub Actions CI
+├── neko2020/            # Main source package (clean-architecture layers)
+│   ├── __main__.py      # Composition root: window, tray, wiring
+│   ├── domain/          # state_machine.py, value_objects.py (pure logic)
+│   ├── application/     # animation_service.py, ports.py (ABCs)
+│   ├── adapters/        # tkinter_renderer.py, tkinter_cursor.py,
+│   │                    #   yaml_config.py
+│   ├── infrastructure/  # files.py, image_loader.py
+│   └── ui/              # config_dialog.py
+├── config/              # default_config.yml
+├── resource/            # 70+ animal sprite sets (32 .ico frames each)
+├── tools/               # AI sprite-set generation scripts
+├── tests/               # pytest test suite (per-module test files)
+└── .github/workflows/   # CI, release build, Claude Code actions
 ```
 
 ## Technology Stack
 
-- **GUI**: Tkinter (transparent overlay, canvas drawing)
+- **GUI**: Tkinter (transparent overlay, canvas drawing, config dialog)
 - **Images**: Pillow (PIL)
 - **Config**: PyYAML
-- **System Tray**: infi-systray
-- **Windows API**: ctypes, pywin32
-- **Distribution**: PyInstaller (single .exe)
-- **Quality**: black, flake8, pre-commit
+- **System Tray**: pystray
+- **Windows API**: ctypes (monitor enumeration, window styles)
+- **Distribution**: PyInstaller (single .exe, released via GitHub Actions)
+- **Quality**: ruff (format + lint), pre-commit, pytest + Codecov

--- a/.agents/summary/components.md
+++ b/.agents/summary/components.md
@@ -5,54 +5,71 @@ description: Major modules and their responsibilities
 
 # Components
 
-## `neko2020/__main__.py` — Entry Point
+## `neko2020/__main__.py` — Composition Root
 
-- Creates full-screen transparent Tkinter window
-- Applies Windows API flags for click-through and Alt+Tab hiding
-- Builds system tray icon with Start / Stop / Restart / Quit callbacks
-- Starts the animation loop via `root.after(fps, tick)`
-- Instantiates `Neko` and `Pet`; calls them each tick
+- Enumerates monitors (ctypes `EnumDisplayMonitors`) and creates a Tkinter window spanning the virtual screen
+- Applies transparency, click-through, and Alt+Tab hiding; positions the window with `SetWindowPos`
+- Builds `YamlConfigProvider`, `TkinterCursorProvider`, `AnimationService`, `ConfigDialog`, and the pystray tray menu (Config / Stop / Start / Restart / Quit)
+- Supplies the session factory that creates a fresh `(NekoStateMachine, TkinterRenderer)` pair on each start/restart, starting the pet at the cursor's monitor
 
-## `neko2020/neko.py` — Neko (State Machine)
+## `domain/state_machine.py` — NekoStateMachine
 
-Central logic class. Responsibilities:
+Central logic class; pure Python, no I/O. Responsibilities:
 
-- Tracks pet position (`x`, `y`) and current `state`
-- Each `tick()` call: reads cursor position, calculates direction angle, chooses next state, advances animation frame
-- Direction chosen by dividing the circle into 8 sectors using `math.sin(math.pi / 8)`
-- Frame index cycles through a 4-element list per state (e.g., `[neko2R_1, neko2R_2]` for right movement)
-- Idle timers count ticks to transition STOP → WASH → SCRATCH → YAWN → SLEEP
+- `tick(cursor, position, size, bounds) -> TickResult(frame_index, x, y)` — the single domain call per frame
+- Computes velocity toward the cursor, capped at `speed.max` and clamped to the monitor bounds (inset by half the sprite size)
+- Direction chosen by dividing the circle into 8 sectors using `sin(pi/8)` thresholds
+- Idle timers drive STOP → WASH (or *_CLAW at screen edges) → SCRATCH → YAWN → SLEEP; cursor movement beyond `idle_space` wakes the pet (AWAKE) before it chases
+- Maps each `State` enum member to a 4-element list of integer frame indices
 
-## `neko2020/pet.py` — Pet (Renderer)
+## `domain/value_objects.py` — Value Objects
 
-- Holds a Tkinter `Canvas` and a `PhotoImage` item
-- `update(state, frame, x, y)` swaps the image and moves the canvas item
-- Caches loaded `ImageTk.PhotoImage` objects to avoid re-loading
-- Reads `animal` from config; if `"random"`, picks a random resource subdirectory at startup
-
-## `neko2020/utils/configs.py` — Config
-
-- Loads `config/default_config.yml` at import time
-- Deep-merges with `~/.config/neko2020/config.yml` (or `$XDG_CONFIG_HOME/neko2020/config.yml`) if present
-- `get_int(path)`, `get_float(path)`, `get_str(path)` — dot-notation accessors
-
-## `neko2020/utils/images.py` — Image Loader
-
-- `load_images(animal, size)` — returns a dict mapping icon-name → `ImageTk.PhotoImage`
-- Looks up sprites under `resource/<animal>/`
-- Icon names are hard-coded in a fixed list matching the standard animation sequence
-
-## `neko2020/utils/classes.py` — Data Classes
-
-Simple named tuples:
+Frozen dataclasses:
 
 | Class | Fields |
 |---|---|
 | `Point` | `x`, `y` |
 | `Size` | `cx`, `cy` |
-| `Rect` | `left`, `top`, `right`, `bottom` |
+| `Rect` | `left`, `top`, `right`, `bottom` (+ `width`/`height` properties) |
 
-## `neko2020/utils/files.py` — File Helpers
+## `application/animation_service.py` — AnimationService
 
-- `get_project_root()` — returns the directory containing the package
-- `select_random_directory(path)` — returns a random subdirectory path (used for random animal)
+- Owns the tick loop via an injected scheduler (`root.after`)
+- `start()` / `stop()` / `restart()` — tray- and dialog-driven lifecycle; restart waits for the loop to stop, then rebuilds the session
+- Picks the monitor rect containing the cursor each tick so the pet stays on the active display
+- Keeps an idle pump running while stopped so the Tk loop stays alive
+
+## `application/ports.py` — Ports
+
+ABCs decoupling the domain/application from Tkinter and YAML: `IConfigProvider` (`get_int/get_float/get_string/reload`), `ICursorProvider` (`get_cursor_position`), `IRenderer` (`render/get_position/get_size/get_bounds`).
+
+## `adapters/tkinter_renderer.py` — TkinterRenderer
+
+- Loads the 32 sprites for the configured animal (resolving `"random"` across bundled and user resource dirs)
+- `render(frame_index, x, y)` redraws the single canvas image when the frame or position changed, converting screen coords to canvas coords
+
+## `adapters/tkinter_cursor.py` — TkinterCursorProvider
+
+- `get_cursor_position()` via `winfo_pointerx/y` (virtual-screen coordinates)
+
+## `adapters/yaml_config.py` — YamlConfigProvider
+
+- `reload()` loads `config/default_config.yml` and deep-merges the user config over it (BaseLoader: scalars stay strings; typed accessors convert)
+- Dot-notation accessors: `get_int`, `get_float`, `get_string`
+
+## `infrastructure/image_loader.py` — Image Loader
+
+- `load_images(animal, scale, user_resource_base)` — returns the ordered list of 32 `ImageTk.PhotoImage` objects plus sprite width/height
+- The ordered icon-name list is hard-coded here; filenames under `resource/<animal>/` must match exactly
+- User resource dir (`~/.config/neko2020/resources/<animal>/`) takes priority over the bundled `resource/`
+
+## `infrastructure/files.py` — File Helpers
+
+- `get_project_root()`, `get_user_resource_dir()`
+- `select_random_directory_merged(project_dir, user_dir)` — random animal across both locations
+
+## `ui/config_dialog.py` — ConfigDialog
+
+- Tray-opened Toplevel with tabbed sections (Appearance / Movement / Behavior Timing / Performance) generated from a declarative field list
+- Animal field is a read-only combobox listing bundled + user sprite sets plus `"random"`
+- Apply writes the user config (with `.bak` backup) and restarts the animation on a background thread

--- a/.agents/summary/data_models.md
+++ b/.agents/summary/data_models.md
@@ -5,17 +5,20 @@ description: Data structures used across the application
 
 # Data Models
 
-## Geometric Types (`utils/classes.py`)
+## Geometric Types (`domain/value_objects.py`)
+
+Frozen dataclasses:
 
 ```python
-Point(x: int, y: int)       # cursor or pet position
-Size(cx: int, cy: int)      # screen or sprite dimensions
-Rect(left, top, right, bottom)  # boundary rectangle
+Point(x: int, y: int)           # cursor or pet position
+Size(cx: int, cy: int)          # sprite dimensions
+Rect(left, top, right, bottom)  # monitor / virtual-screen bounds
+                                #   (.width / .height properties)
 ```
 
-## Animation State
+## Animation State (`domain/state_machine.py`)
 
-States are plain string constants defined at the top of `neko.py`:
+`State` is an `Enum` with 18 members:
 
 ```
 STOP  WASH  SCRATCH  YAWN  SLEEP  AWAKE
@@ -24,36 +27,49 @@ UL_MOVE  UR_MOVE  DL_MOVE  DR_MOVE
 U_CLAW  D_CLAW  L_CLAW  R_CLAW
 ```
 
+## Tick Result
+
+```python
+@dataclass(frozen=True)
+class TickResult:
+    frame_index: int   # index into the 32-icon list
+    x: int             # new pet center (screen coords)
+    y: int
+```
+
 ## Frame Map
 
-A dict in `neko.py` mapping each state string to a list of 2–4 icon name strings (the animation cycle). Example:
+`NekoStateMachine.animation` maps each `State` to a 4-element list of integer frame indices, cycled by `tick_count`. Example:
 
 ```python
 {
-    "R_MOVE": ["neko2R_1", "neko2R_2"],
-    "STOP":   ["stop"],
-    "WASH":   ["wash1", "wash2"],
+    State.STOP:   [28, 28, 28, 28],
+    State.R_MOVE: [5, 6, 5, 6],
+    State.SLEEP:  [30, 30, 31, 31],
     ...
 }
 ```
 
-Icon names correspond directly to filenames under `resource/<animal>/`.
+Indices refer to the ordered icon-name list in `infrastructure/image_loader.py` (`"Awake"`, `"up1"`, …, `"sleep2"` — 32 names). Names correspond directly to `.ico` filenames under `resource/<animal>/`.
 
 ## Configuration Dict
 
-After loading and deep-merging YAMLs, the config is a nested dict:
+After loading and deep-merging YAMLs (`adapters/yaml_config.py`, BaseLoader — all scalars are strings until a typed accessor converts them):
 
 ```python
 {
     "speed": {"max": 60, "min": 2},
-    "offset": {"x": 0, "y": -50},
-    "time": {"stop": 4, "wash": 10, ...},
+    "offset": {"x": 0, "y": -35},
+    "duration": {"stop": 4, "wash": 10, "scratch": 4, "yawn": 3,
+                 "awake": 3, "claw": 10, "awake_rand": 20},
     "idle_space": 10,
     "animal": "neko",
-    "fps": 300
+    "fps": 4,
 }
 ```
 
-## Image Cache
+`fps` is frames per second — the tick delay is `1000 // fps` ms.
 
-`Pet` maintains a dict `{icon_name: ImageTk.PhotoImage}` to avoid re-loading `.ico` files on every frame update.
+## Image List
+
+`TkinterRenderer` holds the ordered `list[ImageTk.PhotoImage]` returned by `load_images()`; `TickResult.frame_index` indexes into it. Images are loaded once per session (start/restart), not per frame.

--- a/.agents/summary/dependencies.md
+++ b/.agents/summary/dependencies.md
@@ -9,46 +9,49 @@ description: External dependencies and their usage
 
 | Package | Version | Usage |
 |---|---|---|
-| `pyyaml` | ^6.0.2 | Parsing `config/*.yml` and user config |
-| `infi-systray` | ^0.1.12 | Windows system tray icon and menu |
-| `pillow` | ^10.4.0 | Loading `.ico` sprite files; `ImageTk.PhotoImage` for Tkinter |
+| `pyyaml` | >=6.0.3 | Parsing `config/*.yml` and user config |
+| `pystray` | >=0.19.5 | System tray icon and menu (runs detached) |
+| `pillow` | >=12.2.0 | Loading `.ico` sprites; `ImageTk.PhotoImage` for Tkinter |
+
+## Optional Extras (sprite generation, `tools/`)
+
+| Extra | Packages | Usage |
+|---|---|---|
+| `imgen` | torch, torchvision, diffusers, transformers, accelerate, safetensors, ollama, rembg | Local Stable Diffusion sprite generation (CUDA GPU) |
+| `imgen-gpt` | openai, rembg | OpenAI gpt-image sprite generation |
 
 ## Standard Library (key modules)
 
 | Module | Usage |
 |---|---|
-| `tkinter` | Fullscreen transparent window, canvas drawing |
-| `ctypes` | Windows API calls (`SetWindowLong`, `GetCursorPos`, transparency) |
-| `math` | `sin`/`atan2` for 8-directional angle calculation |
-| `os`, `pathlib` | Resource path resolution |
-| `threading` | System tray runs on a background thread |
+| `tkinter` | Transparent overlay window, canvas drawing, config dialog |
+| `ctypes` | Win32 calls: `EnumDisplayMonitors`, `SetWindowLongW`, `SetWindowPos` |
+| `math`, `random` | 8-directional angle calculation; timing jitter; random animal |
+| `abc` | Port interfaces in `application/ports.py` |
+| `threading` | Restart synchronization (`Event`); dialog-triggered restart thread |
 
-## Build / Distribution
+## Development (dependency-group `dev`)
 
-| Package | Version | Usage |
-|---|---|---|
-| `pyinstaller` | ^6.10.0 | Compiles to standalone `dist/neko2020.exe` |
-| `pywin32-ctypes` | ^0.2.3 | Required by PyInstaller on Windows |
-| `pefile` | ^2024.8.26 | PE file manipulation (PyInstaller support) |
-| `pywin32` | ^306 | Windows API bindings |
-
-## Development
-
-| Package | Version | Usage |
-|---|---|---|
-| `pytest` | ^8.3.3 | Test runner |
-| `black` | ^24.8.0 | Auto-formatter (79-char line length) |
-| `flake8` | ^7.1.1 | Linter |
-| `pre-commit` | ^3.8.0 | Git hooks (runs black + flake8 on commit) |
+| Package | Usage |
+|---|---|
+| `pytest` | Test runner (CI uploads coverage to Codecov) |
+| `ruff` | Formatter + linter (79-char lines, E/F/W rules) |
+| `pre-commit` | Git hooks running ruff format + lint |
+| `pyinstaller` | Compiles to standalone `dist/neko2020.exe` |
+| `pywin32`, `pywin32-ctypes`, `pefile` | Windows build support (win32 only markers) |
 
 ## CI
 
-| Tool | Usage |
+| Workflow | Usage |
 |---|---|
-| `anthropics/claude-code-action@v1` | AI-powered PR assistant and code review via GitHub Actions |
-| Dependabot | Daily pip dependency updates (max 10 open PRs) |
+| `ci.yml` | Runs pytest with coverage → Codecov |
+| `build-exe.yml` | Builds the exe and creates a GitHub Release tagged from `pyproject.toml` version (master) |
+| `claude.yml` | Responds to `@claude` mentions via `anthropics/claude-code-action@v1` |
+| `claude-code-review.yml` | Automated review on every PR |
+| Dependabot | Dependency update PRs (uv + GitHub Actions) |
 
 ## Platform Constraints
 
-- Runtime is **Windows-only** (`ctypes` calls use Win32 API, `infi-systray` is Windows-only)
+- Runtime is **Windows-only** — the overlay setup in `__main__.py` uses Win32 ctypes calls with no non-Windows code path (pystray itself is cross-platform)
 - Python `>=3.12,<3.14` required
+- Package management via **uv** (`uv.lock`); build backend hatchling

--- a/.agents/summary/index.md
+++ b/.agents/summary/index.md
@@ -14,28 +14,29 @@ Load this file first. Each entry below summarizes a documentation file so you ca
 | File | When to Read |
 |---|---|
 | [codebase_info.md](codebase_info.md) | Quick project metadata — version, stack, directory layout |
-| [architecture.md](architecture.md) | How the transparent overlay window works; the overall process model; animation loop design |
-| [components.md](components.md) | What each Python module/class does and its public methods |
-| [interfaces.md](interfaces.md) | Public APIs between modules; config YAML schema; sprite resource conventions; CI workflows |
-| [data_models.md](data_models.md) | State constants, frame map, geometric types, image cache |
-| [workflows.md](workflows.md) | Startup sequence, per-tick animation flow, idle state transitions, dev/build commands, adding animals |
-| [dependencies.md](dependencies.md) | All runtime/build/dev dependencies and platform constraints |
-| [review_notes.md](review_notes.md) | Known gaps in tests and documentation; platform limitations |
+| [architecture.md](architecture.md) | Clean-architecture layers; how the transparent overlay works; animation loop design |
+| [components.md](components.md) | What each module/class in the layered package does |
+| [interfaces.md](interfaces.md) | Port ABCs between layers; config YAML schema; sprite resource conventions; CI workflows |
+| [data_models.md](data_models.md) | State enum, frame index map, TickResult, geometric types |
+| [workflows.md](workflows.md) | Startup sequence, per-tick flow, idle transitions, config-change flow, dev/build commands, adding animals |
+| [dependencies.md](dependencies.md) | All runtime/optional/dev dependencies and platform constraints |
+| [review_notes.md](review_notes.md) | Known gaps (unused `speed.min`, untested UI), platform limitations, cleanup candidates |
 
 ## Quick Reference
 
-- **Technology**: Python 3.12+, Tkinter, Pillow, ctypes (Win32), PyInstaller
+- **Technology**: Python 3.12+, Tkinter, Pillow, pystray, ctypes (Win32), PyInstaller, uv
 - **Platform**: Windows-only at runtime
 - **Entry point**: `neko2020/__main__.py` (also `python -m neko2020`)
-- **State machine**: `neko2020/neko.py` — 18 states
-- **Renderer**: `neko2020/pet.py`
-- **Config path**: `~/.config/neko2020/config.yml`
-- **Sprites**: `resource/<animal>/` — 32 `.ico` files per animal
+- **State machine**: `neko2020/domain/state_machine.py` — `NekoStateMachine`, 18 states
+- **Renderer**: `neko2020/adapters/tkinter_renderer.py`
+- **Config path**: `~/.config/neko2020/config.yml` (tray Config dialog writes it)
+- **Sprites**: `resource/<animal>/` or `~/.config/neko2020/resources/<animal>/` — 32 `.ico` files per animal
 
 ## Example Queries
 
 - "How do I add a new animal?" → [workflows.md](workflows.md) § Adding a New Animal Type
 - "How does the window stay transparent?" → [architecture.md](architecture.md) § Transparent Overlay Window
-- "What does `tick()` return?" → [interfaces.md](interfaces.md) § Neko class, or [components.md](components.md) § neko.py
+- "What does `tick()` return?" → [interfaces.md](interfaces.md) § Domain API, or [data_models.md](data_models.md) § Tick Result
 - "What config keys exist?" → [interfaces.md](interfaces.md) § Configuration Interface
+- "How does the config dialog apply changes?" → [workflows.md](workflows.md) § Config Change
 - "Why is there no Linux support?" → [review_notes.md](review_notes.md)

--- a/.agents/summary/interfaces.md
+++ b/.agents/summary/interfaces.md
@@ -1,40 +1,56 @@
 ---
 title: Interfaces
-description: Public APIs between modules and external integration points
+description: Ports between layers, config YAML schema, sprite conventions, CI workflows
 ---
 
 # Interfaces
 
-## Module-Level APIs
-
-### `Neko` class (`neko.py`)
+## Application Ports (`application/ports.py`)
 
 ```python
-Neko(config: Config, screen: Size) -> Neko
-Neko.tick(cursor: Point) -> (state: str, frame: str, x: int, y: int)
+class IConfigProvider(ABC):
+    def get_int(path: str) -> int
+    def get_float(path: str) -> float
+    def get_string(path: str) -> str
+    def reload() -> None
+
+class ICursorProvider(ABC):
+    def get_cursor_position() -> Point
+
+class IRenderer(ABC):
+    def render(frame_index: int, x: int, y: int) -> None
+    def get_position() -> Point
+    def get_size() -> Size
+    def get_bounds() -> Rect
 ```
 
-`tick` is the only public method called each animation frame.
+Implementations live in `adapters/` (`YamlConfigProvider`, `TkinterCursorProvider`, `TkinterRenderer`). Config paths use dot notation into the merged YAML tree (e.g., `"speed.max"`, `"duration.stop"`).
 
-### `Pet` class (`pet.py`)
+## Domain API (`domain/state_machine.py`)
 
 ```python
-Pet(root: Tk, config: Config) -> Pet
-Pet.update(state: str, frame: str, x: int, y: int) -> None
-Pet.get_boundary() -> Rect
+NekoStateMachine(*, stop_time, wash_time, scratch_time, yawn_time,
+                 awake_time, claw_time, awake_rand, min_speed,
+                 max_speed, idle_space, offset: Point)
+
+NekoStateMachine.tick(
+    cursor: Point,      # current cursor position
+    position: Point,    # current pet position (from renderer)
+    size: Size,         # sprite size (for boundary insets)
+    bounds: Rect,       # monitor containing the cursor
+) -> TickResult         # (frame_index, x, y)
 ```
 
-`update` swaps the displayed sprite; `get_boundary` returns current screen bounds.
+`tick` is the only call per animation frame; `AnimationService` wires it to the renderer.
 
-### Config API (`utils/configs.py`)
+## AnimationService API (`application/animation_service.py`)
 
 ```python
-get_int(path: str) -> int
-get_float(path: str) -> float
-get_str(path: str) -> str
+AnimationService(config, cursor, session_factory, scheduler, monitors)
+service.start()    # build session via factory, begin ticking
+service.stop()     # halt ticks (idle pump keeps Tk alive)
+service.restart()  # stop, wait, start — reloads config and sprites
 ```
-
-Dot-notation paths into the merged YAML tree (e.g., `"speed.max"`, `"animal"`).
 
 ## Configuration Interface
 
@@ -46,8 +62,8 @@ speed:
   min: 2
 offset:
   x: 0
-  y: -50
-time:
+  y: -35
+duration:
   stop: 4
   wash: 10
   scratch: 4
@@ -57,29 +73,30 @@ time:
   awake_rand: 20
 idle_space: 10
 animal: neko
-fps: 300
+fps: 4
 ```
 
-**User config** location: `~/.config/neko2020/config.yml` (or `$XDG_CONFIG_HOME/neko2020/config.yml`). Any key overrides the default.
+**User config** location: `~/.config/neko2020/config.yml` (respects `XDG_CONFIG_HOME`). Any key overrides the default via deep merge. The tray **Config** dialog (`ui/config_dialog.py`) writes this file (backing up the previous version to `config.yml.bak`) and restarts the animation.
 
 ## Sprite Resource Interface
 
-Each animal directory under `resource/<animal>/` must contain exactly 32 `.ico` files named according to the hard-coded list in `utils/images.py`. Adding a new animal type requires a directory with all 32 frames.
+Each animal directory must contain exactly 32 `.ico` files named according to the hard-coded ordered list in `infrastructure/image_loader.py`. Lookup order: `~/.config/neko2020/resources/<animal>/` first, then bundled `resource/<animal>/`. `animal: random` picks a random directory across both. The `tools/` scripts generate conforming sets with AI (see `tools/README.md`).
 
 ## System Tray Interface
 
-The system tray icon exposes four commands via `infi-systray`:
+`pystray.Icon` menu in `__main__.py`:
 
 | Label | Action |
 |---|---|
-| Start | Resume animation |
+| Config (default, double-click) | Open the settings dialog |
 | Stop | Pause animation |
-| Restart | Recreate Neko and Pet |
+| Start | Resume animation (rebuilds session) |
+| Restart | Reload config, recreate state machine + renderer |
 | Quit | Exit the process |
 
 ## GitHub Actions / CI
 
-Two workflows in `.github/workflows/`:
-
-- **claude.yml** — Responds to `@claude` mentions in PR/issue comments using `anthropics/claude-code-action@v1`
-- **claude-code-review.yml** — Runs automated code review on every PR using the same action with `code-review` plugin
+- **ci.yml** — pytest + coverage upload to Codecov
+- **build-exe.yml** — PyInstaller build; GitHub Release tagged with the `pyproject.toml` version (bump before merging to master)
+- **claude.yml** — responds to `@claude` mentions in PR/issue comments
+- **claude-code-review.yml** — automated review on every PR

--- a/.agents/summary/review_notes.md
+++ b/.agents/summary/review_notes.md
@@ -1,33 +1,30 @@
 ---
 title: Review Notes
-description: Documentation review: consistency and completeness findings
+description: Known gaps, platform limitations, and cleanup candidates
 ---
 
 # Review Notes
 
-## Consistency
-
-No inconsistencies found across the generated documentation files.
-
 ## Completeness Gaps
 
-### Minimal test coverage
-`tests/test_neko2020.py` contains only a version assertion. The state machine (`neko.py`) and config merge logic (`utils/configs.py`) have no test coverage. Any agent helping with testing should note this gap.
-
-### Hard-coded icon name list
-`utils/images.py` contains a hard-coded list of 32 icon names. This list is not documented anywhere — anyone adding a new animal type must reverse-engineer it from the source. Consider extracting it to a constant or config.
+### `speed.min` is unused
+`NekoStateMachine` stores `min_speed` and the config dialog exposes "Min Speed", but nothing reads it — only `speed.max` affects movement. Either implement a behavior for it or remove it from the config, dialog, and constructor.
 
 ### Windows-only — no cross-platform path
-Despite the project description saying "Cross-Platform," the implementation uses Windows-specific APIs exclusively (`ctypes` Win32 calls, `infi-systray`). There is no Linux/macOS code path. This discrepancy is not noted in the README.
+The project description historically said "Cross-Platform," but the overlay setup uses Win32-specific ctypes calls (monitor enumeration, window styles, `SetWindowPos`) with no Linux/macOS code path. `pystray` and the ports-and-adapters structure would support adding one.
 
-### No dual-monitor support
-README notes this limitation but there is no tracking issue or planned fix documented.
+### Hard-coded icon name list
+The ordered list of 32 icon names lives in `infrastructure/image_loader.py`; the per-state frame indices in `domain/state_machine.py` depend on that exact order. Anyone adding sprites must match both. The `tools/` generators produce conforming sets.
 
-### Per-animal config override
-README mentions per-animal config customization but the implementation does not clearly support it. Worth verifying.
+### UI layer untested
+`ui/config_dialog.py` and `__main__.py` have no test coverage (they require a live Tk/Win32 environment). Domain, application, adapters, and infrastructure modules each have a test file under `tests/`.
+
+## Cleanup Candidates
+
+- `neko2020/utils/` may linger as an empty directory (only `__pycache__`) from the pre-layers refactor; the modules moved into `domain/`, `adapters/`, and `infrastructure/`.
 
 ## Recommendations
 
-1. Add unit tests for `Neko` state transitions and `configs.py` deep merge
-2. Document the required 32 icon names in `interfaces.md` or a dedicated sprite spec
-3. Update project description to clarify Windows-only status
+1. Resolve `speed.min` (implement or remove)
+2. Consider extracting the movement math from `NekoStateMachine.tick()` into a dedicated domain helper to shrink the 140-line method and ease testing
+3. If cross-platform support is ever wanted, add a platform adapter for the overlay window alongside the existing Tkinter adapters

--- a/.agents/summary/workflows.md
+++ b/.agents/summary/workflows.md
@@ -11,18 +11,20 @@ description: Key runtime and development workflows
 sequenceDiagram
     participant OS as Windows OS
     participant Main as __main__.py
-    participant Config as configs.py
-    participant Pet as pet.py
-    participant Neko as neko.py
+    participant Service as AnimationService
+    participant Renderer as TkinterRenderer
+    participant SM as NekoStateMachine
 
-    Main->>Config: load default + user config
-    Main->>OS: create fullscreen Tkinter window
-    Main->>OS: apply WS_EX_TRANSPARENT flags (ctypes)
-    Main->>Pet: Pet(root, config)
-    Pet->>Pet: load sprites for animal
-    Main->>Neko: Neko(config, screen_size)
-    Main->>OS: register system tray icon
-    Main->>Main: root.after(fps, tick)
+    Main->>OS: EnumDisplayMonitors (per-display rects)
+    Main->>OS: create virtual-screen Tkinter window
+    Main->>OS: transparentcolor + WS_EX_TOOLWINDOW + SetWindowPos
+    Main->>Main: build YamlConfigProvider, cursor provider
+    Main->>Service: AnimationService(config, cursor, factory, after, monitors)
+    Main->>OS: pystray icon (detached thread)
+    Main->>Service: start()
+    Service->>Service: config.reload()
+    Service->>Renderer: factory: load sprites, start at cursor
+    Service->>SM: factory: build from duration.*/speed.* config
     Main->>Main: root.mainloop()
 ```
 
@@ -30,51 +32,56 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant Main as __main__.py
-    participant Neko as neko.py
-    participant Pet as pet.py
-    participant OS as Windows OS
+    participant Service as AnimationService
+    participant Cursor as TkinterCursorProvider
+    participant SM as NekoStateMachine
+    participant Renderer as TkinterRenderer
 
-    Main->>OS: GetCursorPos()
-    OS-->>Main: cursor Point
-    Main->>Neko: tick(cursor)
-    Neko->>Neko: calc direction angle
-    Neko->>Neko: advance state machine
-    Neko->>Neko: move position toward cursor
-    Neko-->>Main: (state, frame_name, x, y)
-    Main->>Pet: update(state, frame_name, x, y)
-    Pet->>Pet: swap PhotoImage on canvas
-    Main->>Main: root.after(fps, tick)
+    Service->>Cursor: get_cursor_position()
+    Cursor-->>Service: Point
+    Service->>Service: pick monitor rect containing cursor
+    Service->>SM: tick(cursor, position, size, bounds)
+    SM->>SM: velocity toward cursor (capped, clamped)
+    SM->>SM: advance state machine + frame cycle
+    SM-->>Service: TickResult(frame_index, x, y)
+    Service->>Renderer: render(frame_index, x, y)
+    Renderer->>Renderer: redraw canvas image if changed
+    Service->>Service: root.after(1000 // fps, tick)
 ```
 
 ## State Transition (idle path)
 
-```mermaid
-sequenceDiagram
-    participant Neko
-    Note over Neko: cursor stops moving
-    Neko->>Neko: STOP (count ticks up to stop_time)
-    Neko->>Neko: WASH (count up to wash_time)
-    Neko->>Neko: SCRATCH (count up to scratch_time)
-    Neko->>Neko: YAWN (count up to yawn_time)
-    Neko->>Neko: SLEEP (loop until cursor moves)
-    Note over Neko: cursor moves
-    Neko->>Neko: AWAKE (brief wake animation)
-    Neko->>Neko: *_MOVE toward cursor
-```
+When the cursor stops moving (within `idle_space`):
+
+1. `STOP` — after `duration.stop`: → `WASH` mid-screen, or → `*_CLAW` if pinned at a screen edge
+2. `WASH` → `SCRATCH` → `YAWN` → `SLEEP` (each after its `duration.*`)
+3. `SLEEP` loops until the cursor moves
+4. Cursor moves → `AWAKE` (brief, with random extra delay up to `duration.awake_rand`) → one of 8 `*_MOVE` states toward the cursor
+5. Reaching the cursor (or being pinned at a boundary) → `STOP`
+
+## Config Change (tray → dialog)
+
+1. Tray **Config** opens `ConfigDialog` (tabbed form generated from a field list)
+2. Apply validates fields, writes `~/.config/neko2020/config.yml` (previous file backed up to `.bak`)
+3. `AnimationService.restart()` runs on a background thread: stops the loop, reloads config, rebuilds state machine + renderer (new animal/speed/fps take effect)
 
 ## Development Workflow
 
 ```
-poetry install          # install all deps including dev
-poetry run python -m neko2020  # run from source
-pre-commit install      # wire up black + flake8 hooks
-poetry run pytest       # run tests
-poetry run pyinstaller neko2020.spec  # build dist/neko2020.exe
+uv sync                          # install all deps (creates uv.lock)
+uv run python -m neko2020        # run from source
+uv run pre-commit install        # wire up ruff format + lint hooks
+uv run pytest                    # run tests
+uv run ruff format neko2020/ tests/   # format (run before every commit)
+uv run ruff check neko2020/ tests/    # lint
+uv run pyinstaller neko2020.spec # build dist/neko2020.exe
 ```
+
+Git flow: branch from `develop`, PR back to `develop`. Bump `version` in `pyproject.toml` before anything merges to `master` (the release workflow tags from it).
 
 ## Adding a New Animal Type
 
-1. Create `resource/<animal_name>/` directory
-2. Add all 32 `.ico` files named exactly as the hard-coded list in `utils/images.py`
-3. Set `animal: <animal_name>` in `~/.config/neko2020/config.yml`, or use `"random"` to include it in rotation
+1. Create `resource/<animal_name>/` (bundled) or `~/.config/neko2020/resources/<animal_name>/` (user-local)
+2. Add all 32 `.ico` files named exactly as the hard-coded list in `infrastructure/image_loader.py`
+3. Set `animal: <animal_name>` in the user config (or pick it in the Config dialog), or use `"random"` to include it in rotation
+4. Alternatively generate a set with AI: `tools/generate_pet_gpt.py` (OpenAI) or `tools/generate_pet.py` (local Stable Diffusion) — see `tools/README.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,40 @@
 # AGENTS.md — neko2020
 
-Cross-platform desktop pet (oneko-style) for Windows. An animated sprite chases the mouse cursor inside a fullscreen transparent Tkinter overlay, controlled via system tray.
+Desktop pet (oneko-style) for Windows. An animated sprite chases the mouse cursor inside a fullscreen transparent Tkinter overlay spanning all monitors, controlled via system tray.
 
 ## Directory Map
 
 ```
 neko2020/
-├── neko2020/          # Main package
-│   ├── __main__.py    # Entry point: Tkinter window, system tray, animation loop
-│   ├── neko.py        # State machine + movement logic (18 states)
-│   ├── pet.py         # Canvas renderer + sprite loader
-│   └── utils/
-│       ├── classes.py # Point, Size, Rect data classes
-│       ├── configs.py # YAML config loader with deep merge
-│       ├── files.py   # get_project_root(), random dir selection
-│       └── images.py  # load_images() — 32 .ico frames per animal
+├── neko2020/              # Main package (clean-architecture layers)
+│   ├── __main__.py        # Composition root: Tkinter window, Win32 setup,
+│   │                      #   tray menu, wiring of all layers
+│   ├── domain/            # Pure logic, no I/O
+│   │   ├── state_machine.py  # NekoStateMachine — 18-state behavior logic
+│   │   └── value_objects.py  # Point, Size, Rect frozen dataclasses
+│   ├── application/
+│   │   ├── animation_service.py  # Tick loop, start/stop/restart,
+│   │   │                         #   per-monitor bounds selection
+│   │   └── ports.py              # IConfigProvider, ICursorProvider,
+│   │                             #   IRenderer ABCs
+│   ├── adapters/          # Port implementations
+│   │   ├── tkinter_renderer.py   # Canvas drawing + sprite loading
+│   │   ├── tkinter_cursor.py     # Cursor position via Tk
+│   │   └── yaml_config.py        # YAML loader with deep merge
+│   ├── infrastructure/
+│   │   ├── files.py              # Project root, user resource dir,
+│   │   │                         #   random animal selection
+│   │   └── image_loader.py       # Ordered 32-icon list; loads .ico
+│   │                             #   frames via Pillow
+│   └── ui/
+│       └── config_dialog.py      # Tray-opened settings GUI (tabs per
+│                                 #   section, writes user config)
 ├── config/
-│   └── default_config.yml  # Default settings (speed, timing, fps, animal)
-├── resource/          # 50+ animal sprite sets (32 .ico files each)
-├── tests/             # pytest — currently only version assertion
+│   └── default_config.yml  # Default settings (speed, duration, fps, animal)
+├── resource/          # 70+ animal sprite sets (32 .ico files each)
+├── tools/             # AI sprite-set generators (see tools/README.md)
+├── tests/             # pytest suite covering domain, application,
+│                      #   adapters, and infrastructure
 ├── neko2020.spec      # PyInstaller build spec
 └── pyproject.toml     # uv/hatchling config, deps, ruff (79-char)
 ```
@@ -27,21 +43,23 @@ neko2020/
 
 - **Run from source**: `uv run python -m neko2020`
 - **Build executable**: `uv run pyinstaller neko2020.spec` → `dist/neko2020.exe`
-- **User config**: `~/.config/neko2020/config.yml` (deep-merges with `config/default_config.yml`)
+- **User config**: `~/.config/neko2020/config.yml` (deep-merges with `config/default_config.yml`; respects `XDG_CONFIG_HOME`)
+- **User sprite sets**: `~/.config/neko2020/resources/<name>/` (checked before the bundled `resource/`)
 
 ## Architecture Notes
 
-- The fullscreen Tkinter window is transparent via `'-transparentcolor green'` + Win32 `SetWindowLong(WS_EX_TRANSPARENT | WS_EX_LAYERED)`. Mouse events pass through to the desktop.
-- `__main__.py` owns the Tkinter event loop; `root.after(fps, tick)` drives the animation.
-- `Neko.tick(cursor: Point)` returns `(state, frame_name, x, y)` — this is the single call per frame.
-- Sprite frames are hard-coded icon name lists in `neko.py`; filenames must exactly match the list in `utils/images.py`.
+- The fullscreen Tkinter window is transparent via `'-transparentcolor green'`; mouse events pass through to the desktop. `WS_EX_TOOLWINDOW` (ctypes) hides it from Alt+Tab. The window covers the virtual screen across all monitors and is positioned with `SetWindowPos` because Tk `geometry()` can't express negative coordinates.
+- `__main__.py` owns the Tkinter event loop; `AnimationService` re-arms `root.after(1000 // fps, ...)` each tick. The `pystray` tray icon runs detached on its own thread.
+- `NekoStateMachine.tick(cursor, position, size, bounds)` returns `TickResult(frame_index, x, y)` — this is the single domain call per frame. `bounds` is the monitor currently containing the cursor, so the pet stays on that display.
+- Animation frames are 4-element lists of integer indices per state in `domain/state_machine.py`; the indices refer to the ordered icon-name list hard-coded in `infrastructure/image_loader.py`, and those names must exactly match the `.ico` filenames in each sprite directory.
+- `AnimationService.start/stop/restart` (driven from the tray and config dialog) recreate the state machine and renderer via a session factory, so a restart picks up config changes.
 
 ## Repo-Specific Patterns
 
-- **Windows-only at runtime** — despite the "cross-platform" description, ctypes calls are Win32-only and `infi-systray` is Windows-only.
+- **Windows-only at runtime** — the ctypes calls in `__main__.py` are Win32-only (monitor enumeration, window styles). `pystray` itself is cross-platform, but there is no non-Windows code path for the overlay.
 - **Pre-commit hooks** enforce ruff format (79-char) + ruff lint; run `uv run pre-commit install` after cloning.
-- **Adding a new animal**: create `resource/<name>/` with all 32 `.ico` files matching the hard-coded name list in `utils/images.py`, then set `animal: <name>` in user config.
-- **CI**: `.github/workflows/claude.yml` responds to `@claude` mentions; `.github/workflows/claude-code-review.yml` reviews every PR automatically via `anthropics/claude-code-action@v1`.
+- **Adding a new animal**: create `resource/<name>/` (or `~/.config/neko2020/resources/<name>/`) with all 32 `.ico` files matching the hard-coded name list in `infrastructure/image_loader.py`, then set `animal: <name>` in user config. The `tools/` scripts can generate sets with AI.
+- **CI**: `ci.yml` runs pytest with coverage upload to Codecov; `build-exe.yml` builds the exe and creates a GitHub Release on master; `.github/workflows/claude.yml` responds to `@claude` mentions; `claude-code-review.yml` reviews every PR automatically via `anthropics/claude-code-action@v1`.
 
 ## Custom Instructions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ uv run python -m neko2020
 uv run pytest
 
 # Run a single test
-uv run pytest tests/test_neko2020.py::test_version
+uv run pytest tests/test_state_machine.py::test_full_idle_sequence
 
 # Build standalone executable
 uv run pyinstaller neko2020.spec   # output: dist/neko2020.exe
@@ -34,32 +34,49 @@ uv run pre-commit install
 
 ## Architecture
 
-The application is a Windows-only transparent fullscreen overlay. Understanding how it achieves transparency and click-through is essential before touching `__main__.py`:
+The application is a Windows-only transparent fullscreen overlay organized in clean-architecture layers. Understanding how it achieves transparency and click-through is essential before touching `__main__.py`:
 
 - Tkinter window is set to `'-transparentcolor green'` (the green background becomes invisible)
-- `ctypes.windll.user32.SetWindowLong` applies `WS_EX_TRANSPARENT | WS_EX_LAYERED` so mouse events pass through to the desktop
-- `WS_EX_TOOLWINDOW` hides the window from Alt+Tab
+- `root.wm_attributes("-disabled", True)` plus Win32 styles make mouse events pass through to the desktop
+- `WS_EX_TOOLWINDOW` (applied via ctypes) hides the window from Alt+Tab
+- The window spans the virtual screen across all monitors; `EnumDisplayMonitors` provides per-display bounds and `SetWindowPos` positions the window (Tk `geometry()` can't express negative coordinates)
 
-The animation loop runs on Tkinter's `after()` scheduler (not a separate thread). Each tick calls `Neko.tick(cursor)` then `Pet.update(state, frame, x, y)`.
+The animation loop runs on Tkinter's `after()` scheduler (not a separate thread). The system tray icon (`pystray`) runs detached on its own thread.
 
-**Core flow:**
+**Layers** (dependencies point inward only):
 
 ```
-__main__.py  →  Neko.tick()  →  returns (state, frame_name, x, y)
-             →  Pet.update()  →  swaps PhotoImage on canvas
+domain/         # Pure logic, no I/O: state_machine.py, value_objects.py
+application/    # Orchestration: animation_service.py, ports.py (ABCs)
+adapters/       # Port implementations: tkinter_renderer.py,
+                #   tkinter_cursor.py, yaml_config.py
+infrastructure/ # Filesystem/resources: files.py, image_loader.py
+ui/             # config_dialog.py (tray-opened settings GUI)
+__main__.py     # Composition root: window setup, wiring, tray menu
 ```
 
-`Neko` (`neko.py`) owns all behavior logic: an 18-state machine (`STOP`, `WASH`, `SCRATCH`, `YAWN`, `SLEEP`, `AWAKE`, 8 directional moves, 4 claw states). Direction to the cursor is computed by dividing the circle into 8 sectors with `math.sin(math.pi / 8)`. Frame names are hard-coded lists per state; the names must exactly match filenames under `resource/<animal>/`.
+**Core flow per frame:**
 
-`Pet` (`pet.py`) is purely visual: it loads 32 `.ico` sprites via Pillow, caches `ImageTk.PhotoImage` objects, and moves/swaps a single canvas item each frame.
+```
+AnimationService._tick()
+  → NekoStateMachine.tick(cursor, position, size, bounds)
+      returns TickResult(frame_index, x, y)
+  → TkinterRenderer.render(frame_index, x, y)
+      swaps PhotoImage on the canvas
+  → scheduler re-arms root.after(1000 // fps, ...)
+```
+
+`NekoStateMachine` (`domain/state_machine.py`) owns all behavior logic: an 18-state machine (`STOP`, `WASH`, `SCRATCH`, `YAWN`, `SLEEP`, `AWAKE`, 8 directional moves, 4 claw states) as a `State` enum. Direction to the cursor is computed by dividing the circle into 8 sectors with `math.sin(math.pi / 8)`. Each state maps to a 4-element list of integer frame indices; the indices point into the ordered 32-icon list hard-coded in `infrastructure/image_loader.py`, whose names must exactly match filenames under `resource/<animal>/`.
+
+`TkinterRenderer` (`adapters/tkinter_renderer.py`) is purely visual: it loads the 32 `.ico` sprites via Pillow, keeps `ImageTk.PhotoImage` objects, and redraws a single canvas item when the frame or position changes.
 
 ## Configuration
 
-User config at `~/.config/neko2020/config.yml` deep-merges over `config/default_config.yml`. Key values: `speed.max`, `speed.min`, `fps` (ms between frames), `animal` (subdirectory name under `resource/`, or `"random"`), timing values under `time.*`.
+User config at `~/.config/neko2020/config.yml` (respects `XDG_CONFIG_HOME`) deep-merges over `config/default_config.yml`. Key values: `speed.max`, `speed.min`, `fps` (frames per second; tick delay is `1000 // fps` ms), `animal` (subdirectory name under `resource/`, or `"random"`), timing values under `duration.*`, `offset.x`/`offset.y`, `idle_space`. Users normally edit settings through the tray's **Config** dialog (`ui/config_dialog.py`), which writes the user config and restarts the animation.
 
 ## Adding a New Animal
 
-Create `resource/<name>/` with all 32 `.ico` files. File names must exactly match the hard-coded list in `neko2020/utils/images.py`. Set `animal: <name>` in user config or use `"random"` to include it in random rotation.
+Create `resource/<name>/` (or `~/.config/neko2020/resources/<name>/` for user-local sets) with all 32 `.ico` files. File names must exactly match the hard-coded list in `neko2020/infrastructure/image_loader.py`. Set `animal: <name>` in user config or use `"random"` to include it in random rotation. Scripts under `tools/` can generate sprite sets with AI (see `tools/README.md`).
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

The agent-facing docs still described the pre-refactor codebase and had drifted badly since the clean-architecture restructuring (75e37de) and multi-monitor support (438665d). This PR brings CLAUDE.md, AGENTS.md, and all eight `.agents/summary/` files in line with the current code. No code changes.

## What was stale

- **Structure**: docs referenced `neko.py`, `pet.py`, and `utils/` — the code now lives in `domain/`, `application/`, `adapters/`, `infrastructure/`, and `ui/` layers
- **APIs**: `Neko.tick(cursor) -> (state, frame_name, x, y)` is now `NekoStateMachine.tick(cursor, position, size, bounds) -> TickResult(frame_index, x, y)`; frame names became integer indices into the ordered icon list in `infrastructure/image_loader.py`
- **Toolchain**: Poetry / black / flake8 / infi-systray → uv / ruff / pystray; version 0.1.2 → 0.2.1
- **Config**: `time.*` keys → `duration.*`; `fps: 300` (ms) → `fps: 4` (frames per second, delay = `1000 // fps` ms); offset default −50 → −35
- **Missing features**: multi-monitor support, the tray Config dialog, user sprite dir (`~/.config/neko2020/resources/`), `tools/` AI sprite generators, and the real CI workflows (ci.yml, build-exe.yml) were undocumented
- **Tests**: "currently only version assertion" → per-module suite covering domain, application, adapters, and infrastructure
- **review_notes.md**: replaced resolved gaps (no tests, no dual-monitor) with current ones (unused `speed.min`, untested UI layer, stale empty `utils/` dir)

The Custom Instructions section of AGENTS.md (version-bump and ruff-format rules) is preserved unchanged, per its maintenance note.

## Not included

- `README.rst` and `tools/README.md` are already accurate — untouched
- The idle-wandering feature (#194) is not documented here since it hasn't merged; docs describe current `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)